### PR TITLE
update to pull-stream@3 style

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,14 +26,11 @@
   "devDependencies": {
     "mapleTree": "^0.5.1",
     "pull-goodbye": "~0.0.1",
-    "pull-stream": "^2.26.0",
+    "pull-stream": "^3.2.3",
     "tape": "^4.2.0",
     "testling": "^1.7.1",
     "ws": "^0.8.0",
     "wsurl": "^1.0.0"
-  },
-  "dependencies": {
-    "pull-core": "^1.0.0"
   },
   "testling": {
     "files": "test/all.js",

--- a/source.js
+++ b/source.js
@@ -1,4 +1,3 @@
-var pull = require('pull-core');
 var ready = require('./ready');
 
 /**
@@ -9,7 +8,7 @@ var ready = require('./ready');
   <<< examples/read.js
 
 **/
-module.exports = pull.Source(function(socket) {
+module.exports = function(socket) {
   var buffer = [];
   var receiver;
   var ended;
@@ -72,4 +71,7 @@ module.exports = pull.Source(function(socket) {
   };
 
   return read;
-});
+};
+
+
+

--- a/test/read.js
+++ b/test/read.js
@@ -15,17 +15,23 @@ test('create a websocket connection to the server', function(t) {
 test('read values from the socket and end normally', function(t) {
   t.plan(2);
 
-  ws(socket).pipe(pull.collect(function(err, values) {
-    t.ifError(err);
-    t.deepEqual(values, ['a', 'b', 'c', 'd']);
-  }));
+  pull(
+    ws(socket),
+    pull.collect(function(err, values) {
+      t.ifError(err);
+      t.deepEqual(values, ['a', 'b', 'c', 'd']);
+    })
+  );
 });
 
 test('read values from a new socket and end normally', function(t) {
   t.plan(2);
 
-  ws(new WebSocket(endpoint)).pipe(pull.collect(function(err, values) {
-    t.ifError(err);
-    t.deepEqual(values, ['a', 'b', 'c', 'd']);
-  }));
+  pull(
+    ws(new WebSocket(endpoint)),
+    pull.collect(function(err, values) {
+      t.ifError(err);
+      t.deepEqual(values, ['a', 'b', 'c', 'd']);
+    })
+  );
 });


### PR DESCRIPTION
this removes pull-core as a dep (so less js) which removes `.pipe()`
`pull(,,,)` style is better, because it's easier to not miss a comma than to make sure you have counted the right number of closing brackets. Also, it's overall simpler, if all you need is the pull function then you can import `pull-stream/pull` and it's only 30 lines. with this change, pull-ws doesn't have _any_ dependencies. which is often the case for pull-streams now!
