### PR TITLE
expose http request properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ a networking protocol like websockets that does not support it, I suggest
 using [pull-goodbye](https://github.com/dominictarr/pull-goodbye) with your
 protocol.
 
+The duplex stream will also contain a copy of the properties from
+the http request that became the websocket. they are `method`, `url`,
+`headers` and `upgrade`.
+
 ### `pws.sink(socket, opts?)`
 
 Create a pull-stream `Sink` that will write data to the `socket`.

--- a/index.js
+++ b/index.js
@@ -4,8 +4,16 @@ exports.source = require('./source');
 exports.sink = require('./sink');
 
 function duplex (ws, opts) {
+  var req = ws.upgradeReq || {}
   return {
     source: exports.source(ws),
-    sink: exports.sink(ws, opts)
+    sink: exports.sink(ws, opts),
+
+    //http properties - useful for routing or auth.
+    headers: req.headers,
+    url: req.url,
+    upgrade: req.upgrade,
+    method: req.method
   };
 };
+


### PR DESCRIPTION
Exposes `headers`, `url`, `upgrade`, and `method`.

This is needed for routing or for authentication.